### PR TITLE
Use non-zero exit code for broken links

### DIFF
--- a/hydra.py
+++ b/hydra.py
@@ -204,6 +204,9 @@ def main():
     check.TO_PROCESS.put(first_url)
     check.run()
     print(check.make_report())
+    
+    if check.broken:
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This makes it easy to use from a cron job or CI test,
which can then notify people through integrations like chat or email.

I'm experimenting with using hydra in various OpenJS Foundation projects (jquery, qunit, CDN) as replacement for [spider.js](https://github.com/arschmitz/spider.js). I like it a lot so far, it's easy to install, easy to audit, and quite a bit faster too.