### PR TITLE
do not fail on bad links

### DIFF
--- a/hydra.py
+++ b/hydra.py
@@ -158,8 +158,7 @@ class Checker:
             SocketTimeoutError,
             TimeoutError,
             TypeError,
-            UnicodeEncodeError,
-            UnicodeDecodeError,
+            UnicodeError,
         ) as e:
             code = 0
             reason = e


### PR DESCRIPTION
error which triggered failure:
UnicodeError: encoding with 'idna' codec failed
  (UnicodeError: label empty or too long)