### PR TITLE
Add an option to gracefully exit in Configuration, defaulting to the …

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ Hydra can accept an optional JSON configuration file for specific parameters, fo
         "img"
     ],
     "threads": 25,
-    "timeout": 30
+    "timeout": 30,
+    "graceful_exit": "True"
 }
 ```
 
@@ -90,6 +91,7 @@ Possible settings:
 - `tags` - HTML tags to check for links. Defaults to `["a", "link", "img", "script"]`.
 - `threads` - Maximum workers to run. Defaults to `50`.
 - `timeout` - Maximum seconds to wait for HTTP response. Defaults to `60`.
+- `graceful_exit` - If set to `True`, and there are broken links present return `exit code 0` else return `exit code 1`.
 
 ## Test
 

--- a/hydra.py
+++ b/hydra.py
@@ -22,6 +22,7 @@ class Config:
         self.threads = 50
         self.timeout = 60
         self.OK = [200, 999]
+        self.graceful_exit = False
 
         if config_filename != "":
             # Update settings if there is a config file
@@ -36,6 +37,7 @@ class Config:
                 self.threads = config_json.get("threads", self.threads)
                 self.timeout = config_json.get("timeout", self.timeout)
                 self.OK = config_json.get("OK", self.OK)
+                self.graceful_exit = config_json.get("graceful_exit", self.graceful_exit)
 
     def __str__(self):
         text = (
@@ -280,7 +282,7 @@ def main():
     check.run()
     print(check.make_report())
 
-    if check.broken:
+    if check.broken and not check.config.graceful_exit:
         sys.exit(1)
 
 


### PR DESCRIPTION
…original behaviour of returning non-zero exit code if broken links are present

Fixes #15 

The original behaviour is kept as default. 
For graceful exits if there are broken links, user could change the configurations accordingly.